### PR TITLE
fix compile errors of tests on macOS

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,11 +22,15 @@ check_PROGRAMS += myth_free
 check_PROGRAMS += myth_calloc
 check_PROGRAMS += myth_posix_memalign
 check_PROGRAMS += myth_valloc
+if BUILD_TEST_MYTH_MEMALIGN
 check_PROGRAMS += myth_memalign
+endif
 if BUILD_TEST_MYTH_ALIGNED_ALLOC
 check_PROGRAMS += myth_aligned_alloc
 endif
+if BUILD_TEST_MYTH_PVALLOC
 check_PROGRAMS += myth_pvalloc
+endif
 check_PROGRAMS += myth_realloc
 check_PROGRAMS += myth_create_0
 check_PROGRAMS += myth_create_1
@@ -98,11 +102,15 @@ check_PROGRAMS += myth_free_ld
 check_PROGRAMS += myth_calloc_ld
 check_PROGRAMS += myth_posix_memalign_ld
 check_PROGRAMS += myth_valloc_ld
+if BUILD_TEST_MYTH_MEMALIGN
 check_PROGRAMS += myth_memalign_ld
+endif
 if BUILD_TEST_MYTH_ALIGNED_ALLOC
 check_PROGRAMS += myth_aligned_alloc_ld
 endif
+if BUILD_TEST_MYTH_PVALLOC
 check_PROGRAMS += myth_pvalloc_ld
+endif
 check_PROGRAMS += myth_realloc_ld
 check_PROGRAMS += myth_create_0_ld
 check_PROGRAMS += myth_create_1_ld
@@ -135,7 +143,9 @@ check_PROGRAMS += measure_latency_ld
 check_PROGRAMS += measure_wakeup_latency_ld
 check_PROGRAMS += measure_malloc_ld
 check_PROGRAMS += measure_thread_specific_ld
+if BUILD_TEST_PTH_BARRIER
 check_PROGRAMS += pth_barrier_ld
+endif
 check_PROGRAMS += pth_cond_broadcast_0_ld
 check_PROGRAMS += pth_cond_broadcast_1_ld
 check_PROGRAMS += pth_cond_signal_ld
@@ -146,7 +156,9 @@ check_PROGRAMS += pth_lock_ld
 check_PROGRAMS += pth_mixlock_ld
 check_PROGRAMS += pth_mutex_initializer_ld
 check_PROGRAMS += pth_trylock_ld
+if BUILD_TEST_PTH_YIELD
 check_PROGRAMS += pth_yield_ld
+endif
 check_PROGRAMS += new_test_ld
 check_PROGRAMS += myth_create_0_cc_ld
 check_PROGRAMS += myth_create_1_cc_ld
@@ -179,7 +191,9 @@ check_PROGRAMS += measure_latency_cc_ld
 check_PROGRAMS += measure_wakeup_latency_cc_ld
 check_PROGRAMS += measure_malloc_cc_ld
 check_PROGRAMS += measure_thread_specific_cc_ld
+if BUILD_TEST_PTH_BARRIER
 check_PROGRAMS += pth_barrier_cc_ld
+endif
 check_PROGRAMS += pth_cond_broadcast_0_cc_ld
 check_PROGRAMS += pth_cond_broadcast_1_cc_ld
 check_PROGRAMS += pth_cond_signal_cc_ld
@@ -190,7 +204,9 @@ check_PROGRAMS += pth_lock_cc_ld
 check_PROGRAMS += pth_mixlock_cc_ld
 check_PROGRAMS += pth_mutex_initializer_cc_ld
 check_PROGRAMS += pth_trylock_cc_ld
+if BUILD_TEST_PTH_YIELD
 check_PROGRAMS += pth_yield_cc_ld
+endif
 endif
 
 if BUILD_MYTH_DL
@@ -199,11 +215,15 @@ check_PROGRAMS += myth_free_dl
 check_PROGRAMS += myth_calloc_dl
 check_PROGRAMS += myth_posix_memalign_dl
 check_PROGRAMS += myth_valloc_dl
+if BUILD_TEST_MYTH_MEMALIGN
 check_PROGRAMS += myth_memalign_dl
+endif
 if BUILD_TEST_MYTH_ALIGNED_ALLOC
 check_PROGRAMS += myth_aligned_alloc_dl
 endif
+if BUILD_TEST_MYTH_PVALLOC
 check_PROGRAMS += myth_pvalloc_dl
+endif
 check_PROGRAMS += myth_realloc_dl
 check_PROGRAMS += myth_create_0_dl
 check_PROGRAMS += myth_create_1_dl
@@ -236,7 +256,9 @@ check_PROGRAMS += measure_latency_dl
 check_PROGRAMS += measure_wakeup_latency_dl
 check_PROGRAMS += measure_malloc_dl
 check_PROGRAMS += measure_thread_specific_dl
+if BUILD_TEST_PTH_BARRIER
 check_PROGRAMS += pth_barrier_dl
+endif
 check_PROGRAMS += pth_cond_broadcast_0_dl
 check_PROGRAMS += pth_cond_broadcast_1_dl
 check_PROGRAMS += pth_cond_signal_dl
@@ -247,7 +269,9 @@ check_PROGRAMS += pth_lock_dl
 check_PROGRAMS += pth_mixlock_dl
 check_PROGRAMS += pth_mutex_initializer_dl
 check_PROGRAMS += pth_trylock_dl
+if BUILD_TEST_PTH_YIELD
 check_PROGRAMS += pth_yield_dl
+endif
 check_PROGRAMS += new_test_dl
 check_PROGRAMS += myth_create_0_cc_dl
 check_PROGRAMS += myth_create_1_cc_dl
@@ -280,7 +304,9 @@ check_PROGRAMS += measure_latency_cc_dl
 check_PROGRAMS += measure_wakeup_latency_cc_dl
 check_PROGRAMS += measure_malloc_cc_dl
 check_PROGRAMS += measure_thread_specific_cc_dl
+if BUILD_TEST_PTH_BARRIER
 check_PROGRAMS += pth_barrier_cc_dl
+endif
 check_PROGRAMS += pth_cond_broadcast_0_cc_dl
 check_PROGRAMS += pth_cond_broadcast_1_cc_dl
 check_PROGRAMS += pth_cond_signal_cc_dl
@@ -291,7 +317,9 @@ check_PROGRAMS += pth_lock_cc_dl
 check_PROGRAMS += pth_mixlock_cc_dl
 check_PROGRAMS += pth_mutex_initializer_cc_dl
 check_PROGRAMS += pth_trylock_cc_dl
+if BUILD_TEST_PTH_YIELD
 check_PROGRAMS += pth_yield_cc_dl
+endif
 endif
 
 myth_malloc_SOURCES = myth_malloc.c

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -95,13 +95,13 @@ build_triplet = @build@
 host_triplet = @host@
 check_PROGRAMS = myth_malloc$(EXEEXT) myth_free$(EXEEXT) \
 	myth_calloc$(EXEEXT) myth_posix_memalign$(EXEEXT) \
-	myth_valloc$(EXEEXT) myth_memalign$(EXEEXT) $(am__EXEEXT_1) \
-	myth_pvalloc$(EXEEXT) myth_realloc$(EXEEXT) \
-	myth_create_0$(EXEEXT) myth_create_1$(EXEEXT) \
-	myth_create_2$(EXEEXT) myth_create_join_many$(EXEEXT) \
-	myth_yield_0$(EXEEXT) myth_yield_1$(EXEEXT) \
-	myth_yield_2$(EXEEXT) myth_sleep_queue$(EXEEXT) \
-	myth_lock$(EXEEXT) myth_trylock$(EXEEXT) myth_mixlock$(EXEEXT) \
+	myth_valloc$(EXEEXT) $(am__EXEEXT_1) $(am__EXEEXT_2) \
+	$(am__EXEEXT_3) myth_realloc$(EXEEXT) myth_create_0$(EXEEXT) \
+	myth_create_1$(EXEEXT) myth_create_2$(EXEEXT) \
+	myth_create_join_many$(EXEEXT) myth_yield_0$(EXEEXT) \
+	myth_yield_1$(EXEEXT) myth_yield_2$(EXEEXT) \
+	myth_sleep_queue$(EXEEXT) myth_lock$(EXEEXT) \
+	myth_trylock$(EXEEXT) myth_mixlock$(EXEEXT) \
 	myth_cond_signal$(EXEEXT) myth_cond_broadcast_0$(EXEEXT) \
 	myth_cond_broadcast_1$(EXEEXT) myth_barrier$(EXEEXT) \
 	myth_join_counter$(EXEEXT) myth_felock$(EXEEXT) \
@@ -129,21 +129,31 @@ check_PROGRAMS = myth_malloc$(EXEEXT) myth_free$(EXEEXT) \
 	myth_globalattr_set_n_workers_cc$(EXEEXT) \
 	measure_create_cc$(EXEEXT) measure_latency_cc$(EXEEXT) \
 	measure_wakeup_latency_cc$(EXEEXT) measure_malloc_cc$(EXEEXT) \
-	measure_thread_specific_cc$(EXEEXT) $(am__EXEEXT_2) \
-	$(am__EXEEXT_3) $(am__EXEEXT_4) $(am__EXEEXT_5) \
-	$(am__EXEEXT_6) $(am__EXEEXT_7)
-@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__append_1 = myth_aligned_alloc
-@BUILD_MYTH_LD_TRUE@am__append_2 = myth_malloc_ld myth_free_ld \
+	measure_thread_specific_cc$(EXEEXT) $(am__EXEEXT_4) \
+	$(am__EXEEXT_5) $(am__EXEEXT_6) $(am__EXEEXT_7) \
+	$(am__EXEEXT_8) $(am__EXEEXT_9) $(am__EXEEXT_10) \
+	$(am__EXEEXT_11) $(am__EXEEXT_12) $(am__EXEEXT_13) \
+	$(am__EXEEXT_14) $(am__EXEEXT_15) $(am__EXEEXT_16) \
+	$(am__EXEEXT_17) $(am__EXEEXT_18) $(am__EXEEXT_19) \
+	$(am__EXEEXT_20) $(am__EXEEXT_21) $(am__EXEEXT_22) \
+	$(am__EXEEXT_23) $(am__EXEEXT_24) $(am__EXEEXT_25) \
+	$(am__EXEEXT_26) $(am__EXEEXT_27)
+@BUILD_TEST_MYTH_MEMALIGN_TRUE@am__append_1 = myth_memalign
+@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__append_2 = myth_aligned_alloc
+@BUILD_TEST_MYTH_PVALLOC_TRUE@am__append_3 = myth_pvalloc
+@BUILD_MYTH_LD_TRUE@am__append_4 = myth_malloc_ld myth_free_ld \
 @BUILD_MYTH_LD_TRUE@	myth_calloc_ld myth_posix_memalign_ld \
-@BUILD_MYTH_LD_TRUE@	myth_valloc_ld myth_memalign_ld
-@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__append_3 = myth_aligned_alloc_ld
-@BUILD_MYTH_LD_TRUE@am__append_4 = myth_pvalloc_ld myth_realloc_ld \
-@BUILD_MYTH_LD_TRUE@	myth_create_0_ld myth_create_1_ld \
-@BUILD_MYTH_LD_TRUE@	myth_create_2_ld myth_create_join_many_ld \
-@BUILD_MYTH_LD_TRUE@	myth_yield_0_ld myth_yield_1_ld \
-@BUILD_MYTH_LD_TRUE@	myth_yield_2_ld myth_sleep_queue_ld \
-@BUILD_MYTH_LD_TRUE@	myth_lock_ld myth_trylock_ld \
-@BUILD_MYTH_LD_TRUE@	myth_mixlock_ld myth_cond_signal_ld \
+@BUILD_MYTH_LD_TRUE@	myth_valloc_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_MEMALIGN_TRUE@am__append_5 = myth_memalign_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__append_6 = myth_aligned_alloc_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_PVALLOC_TRUE@am__append_7 = myth_pvalloc_ld
+@BUILD_MYTH_LD_TRUE@am__append_8 = myth_realloc_ld myth_create_0_ld \
+@BUILD_MYTH_LD_TRUE@	myth_create_1_ld myth_create_2_ld \
+@BUILD_MYTH_LD_TRUE@	myth_create_join_many_ld myth_yield_0_ld \
+@BUILD_MYTH_LD_TRUE@	myth_yield_1_ld myth_yield_2_ld \
+@BUILD_MYTH_LD_TRUE@	myth_sleep_queue_ld myth_lock_ld \
+@BUILD_MYTH_LD_TRUE@	myth_trylock_ld myth_mixlock_ld \
+@BUILD_MYTH_LD_TRUE@	myth_cond_signal_ld \
 @BUILD_MYTH_LD_TRUE@	myth_cond_broadcast_0_ld \
 @BUILD_MYTH_LD_TRUE@	myth_cond_broadcast_1_ld myth_barrier_ld \
 @BUILD_MYTH_LD_TRUE@	myth_join_counter_ld myth_felock_ld \
@@ -156,15 +166,16 @@ check_PROGRAMS = myth_malloc$(EXEEXT) myth_free$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	measure_create_ld measure_latency_ld \
 @BUILD_MYTH_LD_TRUE@	measure_wakeup_latency_ld \
 @BUILD_MYTH_LD_TRUE@	measure_malloc_ld \
-@BUILD_MYTH_LD_TRUE@	measure_thread_specific_ld pth_barrier_ld \
-@BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_0_ld \
+@BUILD_MYTH_LD_TRUE@	measure_thread_specific_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__append_9 = pth_barrier_ld
+@BUILD_MYTH_LD_TRUE@am__append_10 = pth_cond_broadcast_0_ld \
 @BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_1_ld pth_cond_signal_ld \
 @BUILD_MYTH_LD_TRUE@	pth_create_0_ld pth_create_1_ld \
 @BUILD_MYTH_LD_TRUE@	pth_create_2_ld pth_lock_ld pth_mixlock_ld \
-@BUILD_MYTH_LD_TRUE@	pth_mutex_initializer_ld pth_trylock_ld \
-@BUILD_MYTH_LD_TRUE@	pth_yield_ld new_test_ld \
-@BUILD_MYTH_LD_TRUE@	myth_create_0_cc_ld myth_create_1_cc_ld \
-@BUILD_MYTH_LD_TRUE@	myth_create_2_cc_ld \
+@BUILD_MYTH_LD_TRUE@	pth_mutex_initializer_ld pth_trylock_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__append_11 = pth_yield_ld
+@BUILD_MYTH_LD_TRUE@am__append_12 = new_test_ld myth_create_0_cc_ld \
+@BUILD_MYTH_LD_TRUE@	myth_create_1_cc_ld myth_create_2_cc_ld \
 @BUILD_MYTH_LD_TRUE@	myth_create_join_many_cc_ld \
 @BUILD_MYTH_LD_TRUE@	myth_yield_0_cc_ld myth_yield_1_cc_ld \
 @BUILD_MYTH_LD_TRUE@	myth_yield_2_cc_ld myth_sleep_queue_cc_ld \
@@ -184,26 +195,29 @@ check_PROGRAMS = myth_malloc$(EXEEXT) myth_free$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	measure_create_cc_ld measure_latency_cc_ld \
 @BUILD_MYTH_LD_TRUE@	measure_wakeup_latency_cc_ld \
 @BUILD_MYTH_LD_TRUE@	measure_malloc_cc_ld \
-@BUILD_MYTH_LD_TRUE@	measure_thread_specific_cc_ld \
-@BUILD_MYTH_LD_TRUE@	pth_barrier_cc_ld \
-@BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_0_cc_ld \
+@BUILD_MYTH_LD_TRUE@	measure_thread_specific_cc_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__append_13 = pth_barrier_cc_ld
+@BUILD_MYTH_LD_TRUE@am__append_14 = pth_cond_broadcast_0_cc_ld \
 @BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_1_cc_ld \
 @BUILD_MYTH_LD_TRUE@	pth_cond_signal_cc_ld pth_create_0_cc_ld \
 @BUILD_MYTH_LD_TRUE@	pth_create_1_cc_ld pth_create_2_cc_ld \
 @BUILD_MYTH_LD_TRUE@	pth_lock_cc_ld pth_mixlock_cc_ld \
 @BUILD_MYTH_LD_TRUE@	pth_mutex_initializer_cc_ld \
-@BUILD_MYTH_LD_TRUE@	pth_trylock_cc_ld pth_yield_cc_ld
-@BUILD_MYTH_DL_TRUE@am__append_5 = myth_malloc_dl myth_free_dl \
+@BUILD_MYTH_LD_TRUE@	pth_trylock_cc_ld
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__append_15 = pth_yield_cc_ld
+@BUILD_MYTH_DL_TRUE@am__append_16 = myth_malloc_dl myth_free_dl \
 @BUILD_MYTH_DL_TRUE@	myth_calloc_dl myth_posix_memalign_dl \
-@BUILD_MYTH_DL_TRUE@	myth_valloc_dl myth_memalign_dl
-@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__append_6 = myth_aligned_alloc_dl
-@BUILD_MYTH_DL_TRUE@am__append_7 = myth_pvalloc_dl myth_realloc_dl \
-@BUILD_MYTH_DL_TRUE@	myth_create_0_dl myth_create_1_dl \
-@BUILD_MYTH_DL_TRUE@	myth_create_2_dl myth_create_join_many_dl \
-@BUILD_MYTH_DL_TRUE@	myth_yield_0_dl myth_yield_1_dl \
-@BUILD_MYTH_DL_TRUE@	myth_yield_2_dl myth_sleep_queue_dl \
-@BUILD_MYTH_DL_TRUE@	myth_lock_dl myth_trylock_dl \
-@BUILD_MYTH_DL_TRUE@	myth_mixlock_dl myth_cond_signal_dl \
+@BUILD_MYTH_DL_TRUE@	myth_valloc_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_MEMALIGN_TRUE@am__append_17 = myth_memalign_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__append_18 = myth_aligned_alloc_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_PVALLOC_TRUE@am__append_19 = myth_pvalloc_dl
+@BUILD_MYTH_DL_TRUE@am__append_20 = myth_realloc_dl myth_create_0_dl \
+@BUILD_MYTH_DL_TRUE@	myth_create_1_dl myth_create_2_dl \
+@BUILD_MYTH_DL_TRUE@	myth_create_join_many_dl myth_yield_0_dl \
+@BUILD_MYTH_DL_TRUE@	myth_yield_1_dl myth_yield_2_dl \
+@BUILD_MYTH_DL_TRUE@	myth_sleep_queue_dl myth_lock_dl \
+@BUILD_MYTH_DL_TRUE@	myth_trylock_dl myth_mixlock_dl \
+@BUILD_MYTH_DL_TRUE@	myth_cond_signal_dl \
 @BUILD_MYTH_DL_TRUE@	myth_cond_broadcast_0_dl \
 @BUILD_MYTH_DL_TRUE@	myth_cond_broadcast_1_dl myth_barrier_dl \
 @BUILD_MYTH_DL_TRUE@	myth_join_counter_dl myth_felock_dl \
@@ -216,15 +230,16 @@ check_PROGRAMS = myth_malloc$(EXEEXT) myth_free$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	measure_create_dl measure_latency_dl \
 @BUILD_MYTH_DL_TRUE@	measure_wakeup_latency_dl \
 @BUILD_MYTH_DL_TRUE@	measure_malloc_dl \
-@BUILD_MYTH_DL_TRUE@	measure_thread_specific_dl pth_barrier_dl \
-@BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_0_dl \
+@BUILD_MYTH_DL_TRUE@	measure_thread_specific_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__append_21 = pth_barrier_dl
+@BUILD_MYTH_DL_TRUE@am__append_22 = pth_cond_broadcast_0_dl \
 @BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_1_dl pth_cond_signal_dl \
 @BUILD_MYTH_DL_TRUE@	pth_create_0_dl pth_create_1_dl \
 @BUILD_MYTH_DL_TRUE@	pth_create_2_dl pth_lock_dl pth_mixlock_dl \
-@BUILD_MYTH_DL_TRUE@	pth_mutex_initializer_dl pth_trylock_dl \
-@BUILD_MYTH_DL_TRUE@	pth_yield_dl new_test_dl \
-@BUILD_MYTH_DL_TRUE@	myth_create_0_cc_dl myth_create_1_cc_dl \
-@BUILD_MYTH_DL_TRUE@	myth_create_2_cc_dl \
+@BUILD_MYTH_DL_TRUE@	pth_mutex_initializer_dl pth_trylock_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__append_23 = pth_yield_dl
+@BUILD_MYTH_DL_TRUE@am__append_24 = new_test_dl myth_create_0_cc_dl \
+@BUILD_MYTH_DL_TRUE@	myth_create_1_cc_dl myth_create_2_cc_dl \
 @BUILD_MYTH_DL_TRUE@	myth_create_join_many_cc_dl \
 @BUILD_MYTH_DL_TRUE@	myth_yield_0_cc_dl myth_yield_1_cc_dl \
 @BUILD_MYTH_DL_TRUE@	myth_yield_2_cc_dl myth_sleep_queue_cc_dl \
@@ -244,15 +259,16 @@ check_PROGRAMS = myth_malloc$(EXEEXT) myth_free$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	measure_create_cc_dl measure_latency_cc_dl \
 @BUILD_MYTH_DL_TRUE@	measure_wakeup_latency_cc_dl \
 @BUILD_MYTH_DL_TRUE@	measure_malloc_cc_dl \
-@BUILD_MYTH_DL_TRUE@	measure_thread_specific_cc_dl \
-@BUILD_MYTH_DL_TRUE@	pth_barrier_cc_dl \
-@BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_0_cc_dl \
+@BUILD_MYTH_DL_TRUE@	measure_thread_specific_cc_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__append_25 = pth_barrier_cc_dl
+@BUILD_MYTH_DL_TRUE@am__append_26 = pth_cond_broadcast_0_cc_dl \
 @BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_1_cc_dl \
 @BUILD_MYTH_DL_TRUE@	pth_cond_signal_cc_dl pth_create_0_cc_dl \
 @BUILD_MYTH_DL_TRUE@	pth_create_1_cc_dl pth_create_2_cc_dl \
 @BUILD_MYTH_DL_TRUE@	pth_lock_cc_dl pth_mixlock_cc_dl \
 @BUILD_MYTH_DL_TRUE@	pth_mutex_initializer_cc_dl \
-@BUILD_MYTH_DL_TRUE@	pth_trylock_cc_dl pth_yield_cc_dl
+@BUILD_MYTH_DL_TRUE@	pth_trylock_cc_dl
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__append_27 = pth_yield_cc_dl
 subdir = tests
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
@@ -267,16 +283,18 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/src/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__EXEEXT_1 = myth_aligned_alloc$(EXEEXT)
-@BUILD_MYTH_LD_TRUE@am__EXEEXT_2 = myth_malloc_ld$(EXEEXT) \
+@BUILD_TEST_MYTH_MEMALIGN_TRUE@am__EXEEXT_1 = myth_memalign$(EXEEXT)
+@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__EXEEXT_2 = myth_aligned_alloc$(EXEEXT)
+@BUILD_TEST_MYTH_PVALLOC_TRUE@am__EXEEXT_3 = myth_pvalloc$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@am__EXEEXT_4 = myth_malloc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_free_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_calloc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_posix_memalign_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	myth_valloc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	myth_memalign_ld$(EXEEXT)
-@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__EXEEXT_3 = myth_aligned_alloc_ld$(EXEEXT)
-@BUILD_MYTH_LD_TRUE@am__EXEEXT_4 = myth_pvalloc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	myth_realloc_ld$(EXEEXT) \
+@BUILD_MYTH_LD_TRUE@	myth_valloc_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_MEMALIGN_TRUE@am__EXEEXT_5 = myth_memalign_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__EXEEXT_6 = myth_aligned_alloc_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_MYTH_PVALLOC_TRUE@am__EXEEXT_7 = myth_pvalloc_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@am__EXEEXT_8 = myth_realloc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_create_0_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_create_1_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_create_2_ld$(EXEEXT) \
@@ -307,9 +325,9 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_LD_TRUE@	measure_latency_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	measure_wakeup_latency_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	measure_malloc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	measure_thread_specific_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_barrier_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_0_ld$(EXEEXT) \
+@BUILD_MYTH_LD_TRUE@	measure_thread_specific_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__EXEEXT_9 = pth_barrier_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@am__EXEEXT_10 = pth_cond_broadcast_0_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_1_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_cond_signal_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_create_0_ld$(EXEEXT) \
@@ -318,8 +336,9 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_LD_TRUE@	pth_lock_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_mixlock_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_mutex_initializer_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_trylock_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_yield_ld$(EXEEXT) new_test_ld$(EXEEXT) \
+@BUILD_MYTH_LD_TRUE@	pth_trylock_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__EXEEXT_11 = pth_yield_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@am__EXEEXT_12 = new_test_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_create_0_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_create_1_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	myth_create_2_cc_ld$(EXEEXT) \
@@ -350,8 +369,9 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_LD_TRUE@	measure_latency_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	measure_wakeup_latency_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	measure_malloc_cc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	measure_thread_specific_cc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_barrier_cc_ld$(EXEEXT) \
+@BUILD_MYTH_LD_TRUE@	measure_thread_specific_cc_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__EXEEXT_13 = pth_barrier_cc_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@am__EXEEXT_14 =  \
 @BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_0_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_cond_broadcast_1_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_cond_signal_cc_ld$(EXEEXT) \
@@ -361,17 +381,17 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_LD_TRUE@	pth_lock_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_mixlock_cc_ld$(EXEEXT) \
 @BUILD_MYTH_LD_TRUE@	pth_mutex_initializer_cc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_trylock_cc_ld$(EXEEXT) \
-@BUILD_MYTH_LD_TRUE@	pth_yield_cc_ld$(EXEEXT)
-@BUILD_MYTH_DL_TRUE@am__EXEEXT_5 = myth_malloc_dl$(EXEEXT) \
+@BUILD_MYTH_LD_TRUE@	pth_trylock_cc_ld$(EXEEXT)
+@BUILD_MYTH_LD_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__EXEEXT_15 = pth_yield_cc_ld$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@am__EXEEXT_16 = myth_malloc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_free_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_calloc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_posix_memalign_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	myth_valloc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	myth_memalign_dl$(EXEEXT)
-@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__EXEEXT_6 = myth_aligned_alloc_dl$(EXEEXT)
-@BUILD_MYTH_DL_TRUE@am__EXEEXT_7 = myth_pvalloc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	myth_realloc_dl$(EXEEXT) \
+@BUILD_MYTH_DL_TRUE@	myth_valloc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_MEMALIGN_TRUE@am__EXEEXT_17 = myth_memalign_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_ALIGNED_ALLOC_TRUE@am__EXEEXT_18 = myth_aligned_alloc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_MYTH_PVALLOC_TRUE@am__EXEEXT_19 = myth_pvalloc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@am__EXEEXT_20 = myth_realloc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_create_0_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_create_1_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_create_2_dl$(EXEEXT) \
@@ -402,9 +422,9 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_DL_TRUE@	measure_latency_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	measure_wakeup_latency_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	measure_malloc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	measure_thread_specific_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_barrier_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_0_dl$(EXEEXT) \
+@BUILD_MYTH_DL_TRUE@	measure_thread_specific_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__EXEEXT_21 = pth_barrier_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@am__EXEEXT_22 = pth_cond_broadcast_0_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_1_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_cond_signal_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_create_0_dl$(EXEEXT) \
@@ -413,8 +433,9 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_DL_TRUE@	pth_lock_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_mixlock_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_mutex_initializer_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_trylock_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_yield_dl$(EXEEXT) new_test_dl$(EXEEXT) \
+@BUILD_MYTH_DL_TRUE@	pth_trylock_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__EXEEXT_23 = pth_yield_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@am__EXEEXT_24 = new_test_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_create_0_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_create_1_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	myth_create_2_cc_dl$(EXEEXT) \
@@ -445,8 +466,9 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_DL_TRUE@	measure_latency_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	measure_wakeup_latency_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	measure_malloc_cc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	measure_thread_specific_cc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_barrier_cc_dl$(EXEEXT) \
+@BUILD_MYTH_DL_TRUE@	measure_thread_specific_cc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_BARRIER_TRUE@am__EXEEXT_25 = pth_barrier_cc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@am__EXEEXT_26 =  \
 @BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_0_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_cond_broadcast_1_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_cond_signal_cc_dl$(EXEEXT) \
@@ -456,8 +478,8 @@ CONFIG_CLEAN_VPATH_FILES =
 @BUILD_MYTH_DL_TRUE@	pth_lock_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_mixlock_cc_dl$(EXEEXT) \
 @BUILD_MYTH_DL_TRUE@	pth_mutex_initializer_cc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_trylock_cc_dl$(EXEEXT) \
-@BUILD_MYTH_DL_TRUE@	pth_yield_cc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@	pth_trylock_cc_dl$(EXEEXT)
+@BUILD_MYTH_DL_TRUE@@BUILD_TEST_PTH_YIELD_TRUE@am__EXEEXT_27 = pth_yield_cc_dl$(EXEEXT)
 am_measure_create_OBJECTS = measure_create-measure_create.$(OBJEXT)
 measure_create_OBJECTS = $(am_measure_create_OBJECTS)
 measure_create_DEPENDENCIES = $(myth_ldadd)


### PR DESCRIPTION
On macOS, `make check` causes compile error because some tests use system calls that macOS doesn't provide. This fix avoids the error by disabling such tests according to the result of the configure script.