### PR TITLE
Installing libmyth-dl.a should be avoided

### DIFF
--- a/configure
+++ b/configure
@@ -636,6 +636,8 @@ ac_subst_vars='am__EXEEXT_FALSE
 am__EXEEXT_TRUE
 LTLIBOBJS
 LIBOBJS
+BUILD_MYTH_DL_FALSE
+BUILD_MYTH_DL_TRUE
 CXXCPP
 LT_SYS_LIBRARY_PATH
 OTOOL64
@@ -688,8 +690,6 @@ HAVE_MALLOC_H_FALSE
 HAVE_MALLOC_H_TRUE
 BUILD_DAG_RECORDER_WITH_PAPI_FALSE
 BUILD_DAG_RECORDER_WITH_PAPI_TRUE
-BUILD_MYTH_DL_FALSE
-BUILD_MYTH_DL_TRUE
 BUILD_MYTH_LD_FALSE
 BUILD_MYTH_LD_TRUE
 EGREP
@@ -5697,15 +5697,6 @@ if test "x$ac_cv_have_decl_RTLD_NEXT" = xyes; then :
   have_rtld_next="yes"
 else
   have_rtld_next="no"
-fi
-
-
- if test x"$enable_myth_dl" = "xyes" -a x"$have_rtld_next" = "xyes" ; then
-  BUILD_MYTH_DL_TRUE=
-  BUILD_MYTH_DL_FALSE='#'
-else
-  BUILD_MYTH_DL_TRUE='#'
-  BUILD_MYTH_DL_FALSE=
 fi
 
 
@@ -18001,6 +17992,18 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 # Only expand once:
 
 
+
+ if test x"$enable_myth_dl" = "xyes" && \
+	 test x"$have_rtld_next" = "xyes" && \
+	 test x"$enable_shared" = "xyes"; then
+  BUILD_MYTH_DL_TRUE=
+  BUILD_MYTH_DL_FALSE='#'
+else
+  BUILD_MYTH_DL_TRUE='#'
+  BUILD_MYTH_DL_FALSE=
+fi
+
+
 ac_config_files="$ac_config_files Makefile include/Makefile src/Makefile src/profiler/Makefile src/profiler/dag2any/Makefile src/profiler/drview/Makefile tests/Makefile"
 
 
@@ -18151,10 +18154,6 @@ if test -z "${BUILD_MYTH_LD_TRUE}" && test -z "${BUILD_MYTH_LD_FALSE}"; then
   as_fn_error $? "conditional \"BUILD_MYTH_LD\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
-if test -z "${BUILD_MYTH_DL_TRUE}" && test -z "${BUILD_MYTH_DL_FALSE}"; then
-  as_fn_error $? "conditional \"BUILD_MYTH_DL\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
 if test -z "${BUILD_DAG_RECORDER_WITH_PAPI_TRUE}" && test -z "${BUILD_DAG_RECORDER_WITH_PAPI_FALSE}"; then
   as_fn_error $? "conditional \"BUILD_DAG_RECORDER_WITH_PAPI\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -18197,6 +18196,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${CXX_LAMBDA_AVAILABLE_TRUE}" && test -z "${CXX_LAMBDA_AVAILABLE_FALSE}"; then
   as_fn_error $? "conditional \"CXX_LAMBDA_AVAILABLE\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${BUILD_MYTH_DL_TRUE}" && test -z "${BUILD_MYTH_DL_FALSE}"; then
+  as_fn_error $? "conditional \"BUILD_MYTH_DL\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -254,9 +254,6 @@ AC_CHECK_DECL(RTLD_NEXT,
 #endif
 ])
 
-AM_CONDITIONAL([BUILD_MYTH_DL],
-	[test x"$enable_myth_dl" = "xyes" -a x"$have_rtld_next" = "xyes" ])
-
 
 # -------------
 # -lrt clock_gettime
@@ -567,6 +564,12 @@ AC_CHECK_HEADERS([sqlite3.h], [AC_SUBST(LIBSQLITE3, [-lsqlite3])])
 
 # initialize libtool
 LT_INIT
+
+AM_CONDITIONAL([BUILD_MYTH_DL],
+	[test x"$enable_myth_dl" = "xyes" && \
+	 test x"$have_rtld_next" = "xyes" && \
+	 test x"$enable_shared" = "xyes"])
+
 AC_CONFIG_FILES([
 	Makefile 
 	include/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,7 +44,7 @@ VANILLA_LDFLAGS =
 WRAP_LD_CFLAGS  = -DMYTH_WRAP=MYTH_WRAP_LD
 WRAP_LD_LDFLAGS = @myth-ld.opts
 WRAP_DL_CFLAGS  = -DMYTH_WRAP=MYTH_WRAP_DL
-WRAP_DL_LDFLAGS = 
+WRAP_DL_LDFLAGS = -shared
 
 # required when you use libtool (for building shared libs)
 ACLOCAL_AMFLAGS = -I m4

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -484,7 +484,7 @@ VANILLA_LDFLAGS =
 WRAP_LD_CFLAGS = -DMYTH_WRAP=MYTH_WRAP_LD
 WRAP_LD_LDFLAGS = @myth-ld.opts
 WRAP_DL_CFLAGS = -DMYTH_WRAP=MYTH_WRAP_DL
-WRAP_DL_LDFLAGS = 
+WRAP_DL_LDFLAGS = -shared
 
 # required when you use libtool (for building shared libs)
 ACLOCAL_AMFLAGS = -I m4


### PR DESCRIPTION
It seems useless to install the static library of myth-dl (libmyth-dl.a) in the sense that myth-dl is used only with dynamic linking. This change avoids building and installing libmyth-dl.a.