### PR TITLE
Support for 64-bit ARM processors

### DIFF
--- a/src/myth_config.h
+++ b/src/myth_config.h
@@ -156,6 +156,16 @@
 
 #define WENV_IMPL WENV_IMPL_ELF
 
+#if WENV_IMPL != WENV_IMPL_ELF
+#define MYTH_GET_CURRENT_ENV_INLINE 1
+#elif defined(__aarch64__) && defined(__APPLE__)
+#define MYTH_GET_CURRENT_ENV_INLINE 1
+#elif defined(__aarch64__)
+#define MYTH_GET_CURRENT_ENV_INLINE 0
+#else
+#define MYTH_GET_CURRENT_ENV_INLINE 1
+#endif
+
 //Choose work stealing target at random
 #define WS_TARGET_RANDOM 1
 

--- a/src/myth_config.h
+++ b/src/myth_config.h
@@ -226,6 +226,7 @@
 #define MYTH_ARCH_amd64_knc 5
 #define MYTH_ARCH_sparc_v9  6
 #define MYTH_ARCH_sparc_v8  7
+#define MYTH_ARCH_aarch64   8
 
 // set to 1 to force the universal version
 #define MYTH_FORCE_ARCH_UNIVERSAL 0
@@ -249,6 +250,9 @@
 #else
 #define MYTH_ARCH MYTH_ARCH_sparc_v8
 #endif
+
+#elif defined(__aarch64__)
+#define MYTH_ARCH MYTH_ARCH_aarch64
 
 #else
 #define MYTH_ARCH MYTH_ARCH_UNIVERSAL
@@ -293,6 +297,7 @@
 #define MYTH_CONTEXT_amd64_knc 5
 #define MYTH_CONTEXT_sparc_v9  6
 #define MYTH_CONTEXT_sparc_v8  7
+#define MYTH_CONTEXT_aarch64   8
 
 /* ------------------
    MYTH_WRAP choices

--- a/src/myth_context.h
+++ b/src/myth_context.h
@@ -38,6 +38,9 @@
 #define SAVE_FP   68
 #define SAVE_I7   72
 
+#elif MYTH_ARCH == MYTH_ARCH_aarch64
+#define MYTH_CONTEXT MYTH_CONTEXT_aarch64
+
 #else
 #error "invalid MYTH_ARCH"
 #endif
@@ -52,6 +55,8 @@ typedef struct myth_context {
   uint64_t sp;
 #elif MYTH_CONTEXT == MYTH_CONTEXT_sparc_v8
   uint32_t sp;
+#elif MYTH_CONTEXT == MYTH_CONTEXT_aarch64
+  uint64_t sp;
 #elif MYTH_CONTEXT == MYTH_CONTEXT_UCONTEXT
   ucontext_t uc;
 #else
@@ -87,6 +92,9 @@ extern volatile __thread myth_ctx_withcall_param g_ctx_withcall_params;
 #elif MYTH_CONTEXT == MYTH_CONTEXT_sparc_v9 || MYTH_CONTEXT == MYTH_CONTEXT_sparc_v8
 #include <string.h>
 
+#define MYTH_CTX_CALLBACK static __attribute__((used,noinline))
+
+#elif MYTH_CONTEXT == MYTH_CONTEXT_aarch64
 #define MYTH_CTX_CALLBACK static __attribute__((used,noinline))
 
 #elif MYTH_CONTEXT == MYTH_CONTEXT_UCONTEXT

--- a/src/myth_mem_barrier_func.h
+++ b/src/myth_mem_barrier_func.h
@@ -152,6 +152,65 @@ static inline void myth_rwbarrier() {
 /* end of branch
    MYTH_ARCH == MYTH_ARCH_sparc_v9 || MYTH_ARCH == MYTH_ARCH_sparc_v8 */
 
+#elif MYTH_ARCH == MYTH_ARCH_aarch64
+
+#if MYTH_BARRIER == MYTH_BARRIER_FENCES
+//Guarantees successive reads to be executed after this
+static inline void myth_rbarrier() {
+  asm volatile("dmb ishld" ::: "memory");
+}
+//Guarantees former writes to be executed before this
+static inline void myth_wbarrier() {
+  asm volatile("dmb ishst" ::: "memory");
+}
+//rbarrier+wbarrier
+static inline void myth_rwbarrier() {
+  asm volatile("dmb ish" ::: "memory");
+}
+
+#elif MYTH_BARRIER == MYTH_BARRIER_CILK
+//Memory barriers used by Cilk
+//Guarantees successive reads to be executed after this
+static inline void myth_rbarrier() {
+  asm volatile("dmb ishld":::"memory");
+}
+//Guarantees former writes to be executed before this
+static inline void myth_wbarrier() {
+  asm volatile("dmb ishst":::"memory");
+}
+//rbarrier+wbarrier
+static inline void myth_rwbarrier() {
+  asm volatile("dmb ish":::"memory");
+}
+
+#elif MYTH_BARRIER == MYTH_BARRIER_CILK_WEAK
+static inline void myth_rbarrier() {
+  asm volatile("dmb ishld":::"memory");
+}
+static inline void myth_wbarrier() {
+  asm volatile("dmb ishst":::"memory");
+}
+static inline void myth_rwbarrier() {
+  asm volatile("dmb ish":::"memory");
+}
+#elif MYTH_BARRIER == MYTH_BARRIER_INTRINSIC
+
+static inline void myth_rbarrier() {
+  __sync_synchronize();
+}
+static inline void myth_wbarrier() {
+  __sync_synchronize();
+}
+static inline void myth_rwbarrier() {
+  __sync_synchronize();
+}
+
+#else
+#error "invalid MYTH_BARRIER"
+#endif
+/* end of branch
+   MYTH_ARCH == MYTH_ARCH_aarch64 */
+
 #else  /* other archs */
 
 #warning "Architecture-dependent memory barrier is not defined, substituted by GCC extension"

--- a/src/myth_misc.h
+++ b/src/myth_misc.h
@@ -43,8 +43,11 @@
 #elif MYTH_ARCH == MYTH_ARCH_i386 || MYTH_ARCH == MYTH_ARCH_amd64 || MYTH_ARCH == MYTH_ARCH_amd64_knc
 #define myth_unreachable() asm volatile("ud2\n")
 
-#elif GCC_VERSION >= 40500
+#elif GCC_VERSION >= 40500 || defined(__clang__)
 #define myth_unreachable() __builtin_unreachable()
+
+#elif MYTH_ARCH == MYTH_ARCH_aarch64
+#define myth_unreachable() asm volatile("udf #0\n")
 
 #else
 #define myth_unreachable()

--- a/src/myth_misc_func.h
+++ b/src/myth_misc_func.h
@@ -34,6 +34,10 @@ static inline uint64_t myth_get_rdtsc() {
   uint64_t tick;
   asm volatile("rd %%tick, %0" : "=r" (tick));
   return tick;
+#elif MYTH_ARCH == MYTH_ARCH_aarch64
+  uint64_t tick;
+  asm volatile("mrs %0, cntvct_el0" : "=r" (tick));
+  return tick;
 #else
 #warning "myth_get_rdtsc() not implemented" 
   return 0;

--- a/src/myth_sched.h
+++ b/src/myth_sched.h
@@ -34,7 +34,11 @@ extern int g_sched_prof;
 static inline void myth_env_init(void);
 static inline void myth_env_fini(void);
 static inline void myth_set_current_env(myth_running_env_t e);
+#if MYTH_GET_CURRENT_ENV_INLINE
 static inline myth_running_env_t myth_get_current_env(void);
+#else
+__attribute__((noinline)) myth_running_env_t myth_get_current_env(void);
+#endif
 static inline void init_myth_thread_struct(myth_running_env_t env,myth_thread_t th);
 static inline myth_running_env_t myth_env_get_first_busy(myth_running_env_t e);
 MYTH_CTX_CALLBACK void myth_create_1(void *arg1,void *arg2,void *arg3);

--- a/src/myth_worker.c
+++ b/src/myth_worker.c
@@ -8,6 +8,13 @@
 #include "myth_worker.h"
 #include "myth_worker_func.h"
 
+#if !MYTH_GET_CURRENT_ENV_INLINE
+__attribute__((noinline)) myth_running_env_t myth_get_current_env()
+{
+  return myth_get_current_env_inline();
+}
+#endif
+
 #if EXPERIMENTAL_SCHEDULER
 static myth_thread_t myth_steal_func_with_prob(int rank);
 myth_steal_func_t g_myth_steal_func = myth_steal_func_with_prob;

--- a/src/myth_worker.h
+++ b/src/myth_worker.h
@@ -186,7 +186,11 @@ static void myth_sched_loop(void);
 static inline void myth_env_init(void);
 static inline void myth_env_fini(void);
 static inline void myth_set_current_env(myth_running_env_t e);
+#if MYTH_GET_CURRENT_ENV_INLINE
 static inline myth_running_env_t myth_get_current_env(void);
+#else
+__attribute__((noinline)) myth_running_env_t myth_get_current_env(void);
+#endif
 static inline myth_running_env_t myth_env_get_first_busy(myth_running_env_t e);
 
 static inline void myth_worker_start_ex_body(int rank);

--- a/src/myth_worker_func.h
+++ b/src/myth_worker_func.h
@@ -51,6 +51,10 @@ static int myth_is_myth_worker_body(void) {
   return (myth_get_worker_key() ? 1 : 0);
 }
 
+#if !MYTH_GET_CURRENT_ENV_INLINE
+#define myth_get_current_env myth_get_current_env_inline
+#endif
+
 //TLS implementations
 #if WENV_IMPL == WENV_IMPL_PTHREAD
 //TLS by pthread_key_XXX
@@ -106,6 +110,10 @@ static inline myth_running_env_t myth_get_current_env(void) {
 }
 #else
 #error "invalide WENV_IMPL"
+#endif
+
+#if !MYTH_GET_CURRENT_ENV_INLINE
+#undef myth_get_current_env
 #endif
 
 #if WS_TARGET_RANDOM

--- a/src/profiler/dag_recorder_inl.h
+++ b/src/profiler/dag_recorder_inl.h
@@ -497,6 +497,14 @@ extern "C" {
     return u;
   }
 
+#elif defined(__aarch64__)
+
+  static unsigned long long dr_rdtsc(void) {
+    unsigned long long u;
+    asm volatile("mrs %0, cntvct_el0" : "=r" (u));
+    return u;
+  }
+
 #else
   
   static unsigned long long dr_rdtsc() {

--- a/tests/measure_latency.c
+++ b/tests/measure_latency.c
@@ -14,7 +14,11 @@ typedef unsigned long long ts_t;
 /* TODO : make it run on Sparc */
 static inline ts_t rdtsc() {
   unsigned long long u;
+#if defined(__i386__) || defined(__x86_64__)
   asm volatile ("rdtsc;shlq $32,%%rdx;orq %%rdx,%%rax":"=a"(u)::"%rdx");
+#elif defined(__aarch64__)
+  asm volatile("mrs %0, cntvct_el0" : "=r" (u));
+#endif
   return u;
 }
 static inline ts_t cur_time() {

--- a/tests/measure_wakeup_latency.c
+++ b/tests/measure_wakeup_latency.c
@@ -14,7 +14,11 @@ typedef unsigned long long ts_t;
 /* TODO: make it run on Sparc */
 static inline ts_t rdtsc() {
   unsigned long long u;
+#if defined(__i386__) || defined(__x86_64__)
   asm volatile ("rdtsc;shlq $32,%%rdx;orq %%rdx,%%rax":"=a"(u)::"%rdx");
+#elif defined(__aarch64__)
+  asm volatile("mrs %0, cntvct_el0" : "=r" (u));
+#endif
   return u;
 }
 static inline ts_t cur_time() {

--- a/tests/myth_uncond_bounded_buf.c
+++ b/tests/myth_uncond_bounded_buf.c
@@ -147,6 +147,7 @@ bb_item bb_get(bounded_buffer_t * bb, long n_tries) {
 	if (x.payload != -1 && x.producer != -1) {
 	  bb->a[h % sz].producer = -1;
 	  bb->a[h % sz].payload = -1;
+	  __sync_synchronize();
 	  bb->h = h + 1;	/* advance head pointer */
 	  if (dbg>=2) {
 	    printf(" get [%ld]: -> %ld\n", i, x.payload);


### PR DESCRIPTION
This change adds a support for Linux and macOS on 64-bit ARM processors (aarch64). The main part of this change is assembly code for context switching. This also includes the following changes:

1. The `MYTH_GET_CURRENT_ENV_INLINE` switch is added in `myth_config.h` to control the inlining of `myth_get_current_env`. On aarch64 Linux, inlining `myth_get_current_env` causes unexpected behavior due to the following reason: the C compiler spills the thread index register (tpidr_el0) to the stack and therefore the value of tpidr_el0 is preserved beyond the user thread context switch. This allows workers to corrupt the `env` of other workers, which must be a worker-thread-local storage.
2. A `__sync_synchronize()` is added to `tests/myth_uncond_bounded_buf.c`. Without this, on aarch64 platforms, this test fails due to assertion failure at line 90. I think that this addition does not change the intension of the test.