### PR TITLE
Fix errors on recent Linux and macOS

### DIFF
--- a/configure
+++ b/configure
@@ -6350,6 +6350,30 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
+if test x"$have_pthread_yield" = "xyes" ; then
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+int sched_yield(void) {}
+int pthread_yield(void) {}
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+else
+  have_pthread_yield="no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_pthread_yield" >&5
 $as_echo "$have_pthread_yield" >&6; }
 if test x"$have_pthread_yield" = "xyes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -269,7 +269,7 @@ AC_CHECK_LIB(papi, PAPI_library_init,
 		   [have_papi="yes"],
 		   [have_papi="no"])
 AS_IF([test x"$with_papi" = "xyes" -a x"$have_papi" = "xno"],
-      AC_MSG_ERROR([--with-papi was given, but test for PAPI failed.]))
+      AC_MSG_ERROR([[--with-papi was given, but test for PAPI failed.]]))
 AM_CONDITIONAL([BUILD_DAG_RECORDER_WITH_PAPI],
 	[test x"$with_papi" = "xyes" -a x"$have_papi" = "xyes" ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -466,6 +466,17 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 	[[ pthread_yield(); ]])],
 	[have_pthread_yield="yes"],
 	[have_pthread_yield="no"])
+if test x"$have_pthread_yield" = "xyes" ; then
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _GNU_SOURCE
+#include <pthread.h>
+int sched_yield(void) {}
+int pthread_yield(void) {}
+]],
+	[[]])],
+	[],
+	[have_pthread_yield="no"])
+fi
 AC_MSG_RESULT([$have_pthread_yield])
 if test x"$have_pthread_yield" = "xyes" ; then
    AC_DEFINE_UNQUOTED([HAVE_PTHREAD_YIELD],[1],

--- a/src/myth_wrap_malloc.c
+++ b/src/myth_wrap_malloc.c
@@ -63,6 +63,7 @@ void * __wrap(valloc)(size_t size) {
   return x;
 }
 
+#if HAVE_MEMALIGN
 void * __wrap(memalign)(size_t alignment, size_t size) {
   int _ = enter_wrapped_func("%lu, %lu", alignment, size);
   void * x = real_memalign(alignment, size);
@@ -70,7 +71,9 @@ void * __wrap(memalign)(size_t alignment, size_t size) {
   leave_wrapped_func("%p", x);
   return x;
 }
+#endif
 
+#if HAVE_PVALLOC
 void * __wrap(pvalloc)(size_t size) {
   int _ = enter_wrapped_func("%lu", size);
   void * x = real_pvalloc(size);
@@ -78,3 +81,4 @@ void * __wrap(pvalloc)(size_t size) {
   leave_wrapped_func("%p", x);
   return x;
 }
+#endif

--- a/tests/myth_aligned_alloc.c
+++ b/tests/myth_aligned_alloc.c
@@ -10,7 +10,7 @@ void * aligned_alloc(size_t al, size_t sz);
 
 int main(int argc, char ** argv) {
   size_t al = (argc > 1 ? atol(argv[1]) : 32);
-  size_t sz = (argc > 2 ? atol(argv[2]) : 35);
+  size_t sz = (argc > 2 ? atol(argv[2]) : 64);
   size_t n  = (argc > 3 ? atol(argv[3]) : 3);
   size_t i;
   for (i = 0; i < n; i++) {


### PR DESCRIPTION
This pull request fixes four errors that I encountered when I tried to use MassiveThreads on Ubuntu 24.04 and macOS 14.

1. A compile error related to `pthread_yield` and `sched_yield` occurs on Ubuntu because the former is defined as an asm-level alias of the latter in recent versions of glibc.
2. Regenerating `configure` from `configure.ac` by Autoconf 2.71 causes an syntex error because a necessary quotation is missing in `configure.ac`.
3. Using libmyth-dl on macOS may cause dynamic link error because `real_memalign` and `real_pvalloc` are not defined but required by libmyth-dl.
4. `myth_aligned_alloc` fails on macOS because it gives `aligned_alloc` an invalid argument; according to man page, the second argument of `aligned_alloc` must be a multiple of the first argument.