### PR TITLE
Prevent myth_get_current_env from being inlined in myth_join_body

### DIFF
--- a/src/myth_config.h
+++ b/src/myth_config.h
@@ -156,16 +156,6 @@
 
 #define WENV_IMPL WENV_IMPL_ELF
 
-#if WENV_IMPL != WENV_IMPL_ELF
-#define MYTH_GET_CURRENT_ENV_INLINE 1
-#elif defined(__aarch64__) && defined(__APPLE__)
-#define MYTH_GET_CURRENT_ENV_INLINE 1
-#elif defined(__aarch64__)
-#define MYTH_GET_CURRENT_ENV_INLINE 0
-#else
-#define MYTH_GET_CURRENT_ENV_INLINE 1
-#endif
-
 //Choose work stealing target at random
 #define WS_TARGET_RANDOM 1
 

--- a/src/myth_sched.h
+++ b/src/myth_sched.h
@@ -34,11 +34,7 @@ extern int g_sched_prof;
 static inline void myth_env_init(void);
 static inline void myth_env_fini(void);
 static inline void myth_set_current_env(myth_running_env_t e);
-#if MYTH_GET_CURRENT_ENV_INLINE
 static inline myth_running_env_t myth_get_current_env(void);
-#else
-__attribute__((noinline)) myth_running_env_t myth_get_current_env(void);
-#endif
 static inline void init_myth_thread_struct(myth_running_env_t env,myth_thread_t th);
 static inline myth_running_env_t myth_env_get_first_busy(myth_running_env_t e);
 MYTH_CTX_CALLBACK void myth_create_1(void *arg1,void *arg2,void *arg3);

--- a/src/myth_sched_func.h
+++ b/src/myth_sched_func.h
@@ -664,7 +664,9 @@ static inline int myth_join_body(myth_thread_t th,void **result) {
   myth_spin_unlock_body(&th->lock);
 #endif
   while (th->status != MYTH_STATUS_FREE_READY2) { }
-  myth_join_1(myth_get_current_env(),th,result);
+  // use myth_get_current_env_noinline here to prevent compiler from sharing
+  // the same g_worker_rank before and after context switching
+  myth_join_1(myth_get_current_env_noinline(),th,result);
 #if MYTH_JOIN_PROF
   t3 = myth_get_rdtsc();
   env->prof_data.join_cycles += (t1 - t0) + (t3 - t2);

--- a/src/myth_worker.c
+++ b/src/myth_worker.c
@@ -8,10 +8,9 @@
 #include "myth_worker.h"
 #include "myth_worker_func.h"
 
-#if !MYTH_GET_CURRENT_ENV_INLINE
-__attribute__((noinline)) myth_running_env_t myth_get_current_env()
-{
-  return myth_get_current_env_inline();
+#if WENV_IMPL == WENV_IMPL_ELF
+myth_running_env_t myth_get_current_env_noinline(void) {
+  return myth_get_current_env();
 }
 #endif
 

--- a/src/myth_worker.h
+++ b/src/myth_worker.h
@@ -186,12 +186,14 @@ static void myth_sched_loop(void);
 static inline void myth_env_init(void);
 static inline void myth_env_fini(void);
 static inline void myth_set_current_env(myth_running_env_t e);
-#if MYTH_GET_CURRENT_ENV_INLINE
 static inline myth_running_env_t myth_get_current_env(void);
-#else
-__attribute__((noinline)) myth_running_env_t myth_get_current_env(void);
-#endif
 static inline myth_running_env_t myth_env_get_first_busy(myth_running_env_t e);
+
+#if WENV_IMPL == WENV_IMPL_ELF
+myth_running_env_t myth_get_current_env_noinline(void);
+#else
+#define myth_get_current_env_noinline() myth_get_current_env()
+#endif
 
 static inline void myth_worker_start_ex_body(int rank);
 static inline void myth_startpoint_init_ex_body(int rank);

--- a/src/myth_worker_func.h
+++ b/src/myth_worker_func.h
@@ -51,10 +51,6 @@ static int myth_is_myth_worker_body(void) {
   return (myth_get_worker_key() ? 1 : 0);
 }
 
-#if !MYTH_GET_CURRENT_ENV_INLINE
-#define myth_get_current_env myth_get_current_env_inline
-#endif
-
 //TLS implementations
 #if WENV_IMPL == WENV_IMPL_PTHREAD
 //TLS by pthread_key_XXX
@@ -110,10 +106,6 @@ static inline myth_running_env_t myth_get_current_env(void) {
 }
 #else
 #error "invalide WENV_IMPL"
-#endif
-
-#if !MYTH_GET_CURRENT_ENV_INLINE
-#undef myth_get_current_env
 #endif
 
 #if WS_TARGET_RANDOM


### PR DESCRIPTION
This cancels the changes in commit 4c8694f77ce7e06881c2d8a2c9183a890a22348d and introduces another workaround for the same issue.

The issue occurred on aarch64 linux also occurs on macOS with clang-16. The issue happens if the same `__thread` variable (`g_worker_rank`) is accessed (`myth_get_current_env` is called) twice in the same function before and after context switching.  To my best knowledge, only `myth_join_body` meets this condition.  Therefore, this change prevents the second occurrance of `myth_get_current_env` in `myth_join_body` from being inlined regardless of the target platform and the compiler in use.